### PR TITLE
Fix notification not shown when payloadTransferInfo is empty.

### DIFF
--- a/src/service/plugins/notification.js
+++ b/src/service/plugins/notification.js
@@ -397,7 +397,7 @@ var Plugin = GObject.registerClass({
         let file, path, stream, success, transfer;
 
         try {
-            if (!packet.payloadTransferInfo) {
+            if (!packet.payloadSize) {
                 return null;
             }
 


### PR DESCRIPTION
Notification is not shown when send from KDE Connect Desktop / Sailfish Connect and there exists no icon for the notification.

Bug is caused by wrong detection of empty payload in notification plugin. KDE Connect Desktop Client sends an empty payloadTransferInfo dict when there is no payload and `!{} === false`. Than strange things happen: binary gibberish is send in a new TCP connection to the other side.